### PR TITLE
Sort all properties #318

### DIFF
--- a/Sources/Swagger/Schema/ObjectSchema.swift
+++ b/Sources/Swagger/Schema/ObjectSchema.swift
@@ -57,7 +57,7 @@ extension ObjectSchema: JSONObjectConvertible {
         let requiredPropertyNames: [String] = (jsonDictionary.json(atKeyPath: "required")) ?? []
         let propertiesByName: [String: Schema] = (jsonDictionary.json(atKeyPath: "properties")) ?? [:]
 
-        requiredProperties = requiredPropertyNames.compactMap { name in
+        requiredProperties = requiredPropertyNames.sorted().compactMap { name in
             if let schema = propertiesByName[name] {
                 return Property(name: name, required: true, schema: schema)
             }
@@ -71,7 +71,7 @@ extension ObjectSchema: JSONObjectConvertible {
             return nil
         }.sorted { $0.name < $1.name }
 
-        properties = requiredProperties + optionalProperties
+        properties = (requiredProperties + optionalProperties).sorted { $0.name < $1.name }
 
         minProperties = jsonDictionary.json(atKeyPath: "minProperties")
         maxProperties = jsonDictionary.json(atKeyPath: "maxProperties")


### PR DESCRIPTION
[dankinsoid](https://github.com/dankinsoid) commented [last month](https://github.com/yonaskolb/SwagGen/pull/318#issue-1619971380)
Swggen sorts only optional properties, which sometimes results in shuffling properties with minor schema changes.

ref: https://github.com/yonaskolb/SwagGen/pull/318